### PR TITLE
Iterate over the code points of _value_ using the same algorithm used to interpret strings passed to `eval`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1803,22 +1803,21 @@ li.menu-search-result-term:before {
     display: none; 
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-quotejsonstring" title="Runtime Semantics: QuoteJSONString ( value )"><span class="secnum">1</span> RS: QuoteJSONString ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="shortname first">Proposal  <a href="https://github.com/gibson042/ecma262-proposal-well-formed-stringify">proposal-well-formed-stringify</a></h1><h1 class="version">Stage 2 Draft / August 14, 2018</h1><h1 class="title">Well-formed JSON.stringify</h1>
+</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-quotejsonstring" title="Runtime Semantics: QuoteJSONString ( value )"><span class="secnum">1</span> RS: QuoteJSONString ( <var>value</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="shortname first">Proposal  <a href="https://github.com/gibson042/ecma262-proposal-well-formed-stringify">proposal-well-formed-stringify</a></h1><h1 class="version">Stage 2 Draft / August 27, 2018</h1><h1 class="title">Well-formed JSON.stringify</h1>
 <emu-biblio href="./missing-productions.json"></emu-biblio>
 
 
 <emu-clause id="sec-quotejsonstring" aoid="QuoteJSONString">
   <h1><span class="secnum">1</span>Runtime Semantics: QuoteJSONString ( <var>value</var> )</h1>
   <p>The abstract operation QuoteJSONString with argument <var>value</var> wraps a String value in QUOTATION MARK code units and escapes certain other code units within it.</p>
-  <emu-alg><ol><li>Let <var>product</var> be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).</li><li>For each code unit <var>C</var> in <var>value</var>, do<ol><li>If the numeric value of <var>C</var> is listed in the Code Unit Value column of <emu-xref href="#table-json-single-character-escapes" id="_ref_0"><a href="#table-json-single-character-escapes">Table 1</a></emu-xref>, then<ol><li>Set <var>product</var> to the string-concatenation of <var>product</var> and the Escape Sequence for <var>C</var> as specified in <emu-xref href="#table-json-single-character-escapes" id="_ref_1"><a href="#table-json-single-character-escapes">Table 1</a></emu-xref>.</li></ol></li><li>Else if <var>C</var> has a numeric value less than 0x0020 (SPACE), then<ol><li>Set <var>product</var> to the string-concatenation of <var>product</var> and UnicodeEscape(<var>C</var>).</li></ol></li><li><ins>Else if <var>C</var> is a <emu-xref href="#high-surrogate-code-unit"><a href="https://tc39.github.io/ecma262/#high-surrogate-code-unit">high-surrogate code unit</a></emu-xref> and is not followed by a <emu-xref href="#low-surrogate-code-unit"><a href="https://tc39.github.io/ecma262/#low-surrogate-code-unit">low-surrogate code unit</a></emu-xref>, then</ins><ol><li><ins>Set <var>product</var> to the string-concatenation of <var>product</var> and UnicodeEscape(<var>C</var>).</ins></li></ol></li><li><ins>Else if <var>C</var> is a <emu-xref href="#low-surrogate-code-unit"><a href="https://tc39.github.io/ecma262/#low-surrogate-code-unit">low-surrogate code unit</a></emu-xref> and is not preceded by a <emu-xref href="#high-surrogate-code-unit"><a href="https://tc39.github.io/ecma262/#high-surrogate-code-unit">high-surrogate code unit</a></emu-xref>, then</ins><ol><li><ins>Set <var>product</var> to the string-concatenation of <var>product</var> and UnicodeEscape(<var>C</var>).</ins></li></ol></li><li>Else,<ol><li>Set <var>product</var> to the string-concatenation of <var>product</var> and <var>C</var>.</li></ol></li></ol></li><li>Set <var>product</var> to the string-concatenation of <var>product</var> and the code unit 0x0022 (QUOTATION MARK).</li><li>Return <var>product</var>.
+  <emu-alg><ol><li>Let <var>product</var> be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).</li><li>For each code <del>unit</del><ins>point</ins> <var>C</var> in <var>value</var> <ins>when interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">6.1.4</a></emu-xref></ins>, do<ol><li>If <del>the numeric value of</del> <var>C</var> is listed in the Code <del>Unit Value</del><ins>Point</ins> column of <emu-xref href="#table-json-single-character-escapes" id="_ref_0"><a href="#table-json-single-character-escapes">Table 1</a></emu-xref>, then<ol><li>Set <var>product</var> to the string-concatenation of <var>product</var> and the Escape Sequence for <var>C</var> as specified in <emu-xref href="#table-json-single-character-escapes" id="_ref_1"><a href="#table-json-single-character-escapes">Table 1</a></emu-xref>.</li></ol></li><li>Else if <var>C</var> has a numeric value less than 0x0020 (SPACE), <ins>or <var>C</var> has the same numeric value as a <emu-xref href="#leading-surrogate-code-unit"><a href="https://tc39.github.io/ecma262/#leading-surrogate-code-unit">leading-surrogate code unit</a></emu-xref> or <emu-xref href="#trailing-surrogate-code-unit"><a href="https://tc39.github.io/ecma262/#trailing-surrogate-code-unit">trailing-surrogate code unit</a></emu-xref>,</ins> then<ol><li><ins>Let <var>unit</var> be a code unit whose numeric value is that of <var>C</var>.</ins></li><li>Set <var>product</var> to the string-concatenation of <var>product</var> and UnicodeEscape(<var>unit</var>).</li></ol></li><li>Else,<ol><li>Set <var>product</var> to the string-concatenation of <var>product</var> and <ins>the <emu-xref aoid="UTF16Encoding" id="_ref_2"><a href="https://tc39.github.io/ecma262/#sec-utf16encoding">UTF16Encoding</a></emu-xref> of</ins> <var>C</var>.</li></ol></li></ol></li><li>Set <var>product</var> to the string-concatenation of <var>product</var> and the code unit 0x0022 (QUOTATION MARK).</li><li>Return <var>product</var>.
   </li></ol></emu-alg>
   <emu-table id="table-json-single-character-escapes" caption="JSON Single Character Escape Sequences"><figure><figcaption>Table 1: JSON Single Character Escape Sequences</figcaption>
     <table>
       <tbody>
       <tr>
         <th>
-          Code Unit Value
-        
+          Code  <del>Unit Value</del><ins>Point</ins>
         </th>
         <th>
           Unicode Character Name
@@ -1831,8 +1830,7 @@ li.menu-search-result-term:before {
       </tr>
       <tr>
         <td>
-          <code>0x0008</code>
-        
+          <del><code>0x0008</code></del><ins>U+0008</ins>
         </td>
         <td>
           BACKSPACE
@@ -1845,8 +1843,7 @@ li.menu-search-result-term:before {
       </tr>
       <tr>
         <td>
-          <code>0x0009</code>
-        
+          <del><code>0x0009</code></del><ins>U+0009</ins>
         </td>
         <td>
           CHARACTER TABULATION
@@ -1859,8 +1856,7 @@ li.menu-search-result-term:before {
       </tr>
       <tr>
         <td>
-          <code>0x000A</code>
-        
+          <del><code>0x000A</code></del><ins>U+000A</ins>
         </td>
         <td>
           LINE FEED (LF)
@@ -1873,8 +1869,7 @@ li.menu-search-result-term:before {
       </tr>
       <tr>
         <td>
-          <code>0x000C</code>
-        
+          <del><code>0x000C</code></del><ins>U+000C</ins>
         </td>
         <td>
           FORM FEED (FF)
@@ -1887,8 +1882,7 @@ li.menu-search-result-term:before {
       </tr>
       <tr>
         <td>
-          <code>0x000D</code>
-        
+          <del><code>0x000D</code></del><ins>U+000D</ins>
         </td>
         <td>
           CARRIAGE RETURN (CR)
@@ -1901,8 +1895,7 @@ li.menu-search-result-term:before {
       </tr>
       <tr>
         <td>
-          <code>0x0022</code>
-        
+          <del><code>0x0022</code></del><ins>U+0022</ins>
         </td>
         <td>
           QUOTATION MARK
@@ -1915,8 +1908,7 @@ li.menu-search-result-term:before {
       </tr>
       <tr>
         <td>
-          <code>0x005C</code>
-        
+          <del><code>0x005C</code></del><ins>U+005C</ins>
         </td>
         <td>
           REVERSE SOLIDUS

--- a/missing-productions.json
+++ b/missing-productions.json
@@ -7,13 +7,13 @@
     },
     {
       "type": "term",
-      "term": "high-surrogate code unit",
-      "id": "high-surrogate-code-unit"
+      "id": "leading-surrogate-code-unit",
+      "term": "leading-surrogate code unit"
     },
     {
       "type": "term",
-      "term": "low-surrogate code unit",
-      "id": "low-surrogate-code-unit"
+      "id": "trailing-surrogate-code-unit",
+      "term": "trailing-surrogate code unit"
     }
   ]
 }

--- a/spec.emu
+++ b/spec.emu
@@ -16,17 +16,14 @@ contributors: Richard Gibson
   <p>The abstract operation QuoteJSONString with argument _value_ wraps a String value in QUOTATION MARK code units and escapes certain other code units within it.</p>
   <emu-alg>
     1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
-    1. For each code unit _C_ in _value_, do
-      1. If the numeric value of _C_ is listed in the Code Unit Value column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
+    1. For each code <del>unit</del><ins>point</ins> _C_ in _value_ <ins>when interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref></ins>, do
+      1. If <del>the numeric value of</del> _C_ is listed in the Code <del>Unit Value</del><ins>Point</ins> column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
         1. Set _product_ to the string-concatenation of _product_ and the Escape Sequence for _C_ as specified in <emu-xref href="#table-json-single-character-escapes"></emu-xref>.
-      1. Else if _C_ has a numeric value less than 0x0020 (SPACE), then
-        1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_C_).
-      1. <ins>Else if _C_ is a <emu-xref href="#high-surrogate-code-unit"></emu-xref> and is not followed by a <emu-xref href="#low-surrogate-code-unit"></emu-xref>, then</ins>
-        1. <ins>Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_C_).</ins>
-      1. <ins>Else if _C_ is a <emu-xref href="#low-surrogate-code-unit"></emu-xref> and is not preceded by a <emu-xref href="#high-surrogate-code-unit"></emu-xref>, then</ins>
-        1. <ins>Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_C_).</ins>
+      1. Else if _C_ has a numeric value less than 0x0020 (SPACE), <ins>or _C_ has the same numeric value as a <emu-xref href="#leading-surrogate-code-unit"></emu-xref> or <emu-xref href="#trailing-surrogate-code-unit"></emu-xref>,</ins> then
+        1. <ins>Let _unit_ be a code unit whose numeric value is that of _C_.</ins>
+        1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_unit_).
       1. Else,
-        1. Set _product_ to the string-concatenation of _product_ and _C_.
+        1. Set _product_ to the string-concatenation of _product_ and <ins>the <emu-xref aoid="UTF16Encoding"></emu-xref> of</ins> _C_.
     1. Set _product_ to the string-concatenation of _product_ and the code unit 0x0022 (QUOTATION MARK).
     1. Return _product_.
   </emu-alg>
@@ -35,7 +32,7 @@ contributors: Richard Gibson
       <tbody>
       <tr>
         <th>
-          Code Unit Value
+          Code <del>Unit Value</del><ins>Point</ins>
         </th>
         <th>
           Unicode Character Name
@@ -46,7 +43,7 @@ contributors: Richard Gibson
       </tr>
       <tr>
         <td>
-          `0x0008`
+          <del>`0x0008`</del><ins>U+0008</ins>
         </td>
         <td>
           BACKSPACE
@@ -57,7 +54,7 @@ contributors: Richard Gibson
       </tr>
       <tr>
         <td>
-          `0x0009`
+          <del>`0x0009`</del><ins>U+0009</ins>
         </td>
         <td>
           CHARACTER TABULATION
@@ -68,7 +65,7 @@ contributors: Richard Gibson
       </tr>
       <tr>
         <td>
-          `0x000A`
+          <del>`0x000A`</del><ins>U+000A</ins>
         </td>
         <td>
           LINE FEED (LF)
@@ -79,7 +76,7 @@ contributors: Richard Gibson
       </tr>
       <tr>
         <td>
-          `0x000C`
+          <del>`0x000C`</del><ins>U+000C</ins>
         </td>
         <td>
           FORM FEED (FF)
@@ -90,7 +87,7 @@ contributors: Richard Gibson
       </tr>
       <tr>
         <td>
-          `0x000D`
+          <del>`0x000D`</del><ins>U+000D</ins>
         </td>
         <td>
           CARRIAGE RETURN (CR)
@@ -101,7 +98,7 @@ contributors: Richard Gibson
       </tr>
       <tr>
         <td>
-          `0x0022`
+          <del>`0x0022`</del><ins>U+0022</ins>
         </td>
         <td>
           QUOTATION MARK
@@ -112,7 +109,7 @@ contributors: Richard Gibson
       </tr>
       <tr>
         <td>
-          `0x005C`
+          <del>`0x005C`</del><ins>U+005C</ins>
         </td>
         <td>
           REVERSE SOLIDUS


### PR DESCRIPTION
There's already spec algorithm/text for interpreting JS strings that contain lone surrogates, in the manner that QuoteJSONString wants to interpret them -- as code points, with lone surrogates interpreted as whole code points.  We should reuse that.

Additionally, the main spec already has definitions for leading/trailing surrogate that can be reused.  That seems better than introducing new definitions that cross-reference elsewhere.

I have no idea what the custom is for dels/inses or how exactly this is supposed to be written -- the existing dels/inses do not match up with the spec text in https://github.com/tc39/ecma262 right now, so I'm not sure what they're acting against -- so I mostly just used them with respect to the text currently there.