### PR TITLE
Shipped in FF 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ The specification is available in [ecmarkup](spec.emu) or [rendered HTML](https:
 
 ## Implementations
 * [V8](https://bugs.chromium.org/p/v8/issues/detail?id=7782), enabled by default in V8 v7.2.10 and Chrome 72
-* [SpiderMonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=1469021), planned to ship in Firefox 64
+* [SpiderMonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=1469021), shipped in Firefox 64


### PR DESCRIPTION
https://hacks.mozilla.org/2018/12/firefox-64-released/